### PR TITLE
fix the warning info bug

### DIFF
--- a/notebook/statistical-mechanics/ising_model.ipynb
+++ b/notebook/statistical-mechanics/ising_model.ipynb
@@ -332,7 +332,7 @@
     "    \n",
     "    See e.g.: https://en.wikipedia.org/wiki/Square_lattice_Ising_model\n",
     "    \"\"\"\n",
-    "    temperature = np.linspace(0.01, 4, 500)\n",
+    "    temperature = np.linspace(0.01, 4, 500, dtype=np.float128)\n",
     "    magnetization = np.zeros(len(temperature))\n",
     "    Tc = 2 * J / k_B / np.log(1 + np.sqrt(2))\n",
     "    magnetization[temperature < Tc] = (1-1./(np.sinh(2 * J / k_B / temperature[temperature < Tc])**4))**(1/8)\n",
@@ -524,7 +524,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.8"
+   "version": "3.11.5"
   },
   "voila": {
    "authors": "Dou Du and Giovanni Pizzi"


### PR DESCRIPTION
Fix the warning massage with "dtype=np.float128"