### PR TITLE
use classic_tree for binder links

### DIFF
--- a/jupyter_config.json
+++ b/jupyter_config.json
@@ -2,6 +2,7 @@
   "VoilaConfiguration": {
     "enable_nbextensions": true,  
     "theme": "light",
+    "classic_tree": true,
     "template": "osscar"
   }
 }


### PR DESCRIPTION
Fix the binder links without OSSCAR template by using "classic_tree: true"